### PR TITLE
Fix target node hostname

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-ARWEAVE_NODES=["http://arweave-node:1984"]
+ARWEAVE_NODES=["http://localhost:1984"]
 DATABASE_HOST=postgres
 DATABASE_PORT=5432
 DATABASE_USER=arweave


### PR DESCRIPTION
Fixes issue where,  instead of localhost:1984, navigating to localhost:3000 redirected to arweave-node:1984